### PR TITLE
use input and change events to handle autofill and copy/paste validation and formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@degjs/simple-mask",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Simple masking plugin",
     "keywords": [
         "masking",
@@ -17,7 +17,7 @@
     },
     "bugs": "https://github.com/DEGJS/simpleMask/issues",
     "files": [
-        "src"
+        "src/simpleMask.js"
     ],
     "main": "src/simpleMask.js",
     "publishConfig": {

--- a/src/simpleMask.js
+++ b/src/simpleMask.js
@@ -7,7 +7,7 @@ const simpleMask = (containerEl, options = {}) => {
         alphanumeric: false,
         customPattern: null,
         alphanumericPattern: /^[a-zA-Z0-9\.]*$/,
-        numberPattern: /[0-9\/]+/,
+        numberPattern: /[\d]+/,
         onMaskCallback: null,
         onFailedInputCallback: null,
     };
@@ -65,25 +65,38 @@ const simpleMask = (containerEl, options = {}) => {
                 specialCharactersArray.push({ char, index });
             }
         });
-
+       
         return specialCharactersArray;
     };
 
     const bindEvents = () => {
         inputEl.addEventListener('focusin', maskInput);
         inputEl.addEventListener('focusout', maskInput);
-        inputEl.addEventListener('keypress', checkForInvalidKey);
+        inputEl.addEventListener('change', maskInput);
+        inputEl.addEventListener('input', onInput);
     };
 
     const unbindEvents = () => {
         inputEl.removeEventListener('focusin', maskInput);
         inputEl.removeEventListener('focusout', maskInput);
-        inputEl.removeEventListener('keypress', checkForInvalidKey);
+        inputEl.removeEventListener('change', maskInput);
+        inputEl.removeEventListener('input', onInput);
     }
 
     const maskInput = (e) => {
-        if (inputEl.value.length !== 0 && inputEl.value.length >= getFormatLength() ) {
-            const value = getMaskValue(arrayOfSpecialCharactersInFormat, getMaskMethod(e));
+        const maskMethod = getMaskMethod(e);
+
+        /* 
+            Perform masking/unmasking if:
+            1) value is not empty,
+            2) value meets minimum length of format, and
+            3) value will be unmasked or value will be masked and is not already masked
+        */
+        if (inputEl.value.length !== 0 && 
+            inputEl.value.length >= getFormatLength() && 
+            (maskMethod !== maskMethods.forward || !isValueMasked(inputEl.value))
+        ) {
+            const value = getMaskValue(arrayOfSpecialCharactersInFormat, maskMethod);
             setInputValue(value);
 
             if (settings.onMaskCallback) {
@@ -91,6 +104,13 @@ const simpleMask = (containerEl, options = {}) => {
             }
         }
     };
+
+    /* Assume value is masked if it contains at least one special character */
+    const isValueMasked = value => {
+        return value.split('').some(char => 
+            arrayOfSpecialCharactersInFormat.some(specialChar => specialChar.char === char)
+        );
+    }
 
     const getMaskMethod = (e) => e.type === 'focusin' ? maskMethods.reverse : maskMethods.forward;
 
@@ -115,16 +135,27 @@ const simpleMask = (containerEl, options = {}) => {
         return output;
     };
 
+    const onInput = () => {
+        const validValue = removeInvalidCharacters(inputEl.value, getKeyPattern(), getFormatLength());
 
-    const checkForInvalidKey = e => {
-        if (inputEl.value.length === getFormatLength() || !keyMatchesPattern(e.key)) {
-            e.preventDefault();
+        if(inputEl.value !== validValue) {
+            inputEl.value = validValue;
 
             if(settings.onFailedInputCallback) {
                 settings.onFailedInputCallback(inputEl.value);
             }
         }
-    };
+    }
+
+    const removeInvalidCharacters = (value, pattern, maxLength) => {
+        return value.split('').reduce((newValue, char) => {
+            if(newValue.length < maxLength && pattern.test(char)) {
+                newValue += char;
+            }
+
+            return newValue;
+        }, '');
+    }
 
     const getFormatLength = () => {
         let formatLength;
@@ -137,12 +168,6 @@ const simpleMask = (containerEl, options = {}) => {
 
         return formatLength;
     };
-
-    const keyMatchesPattern = (pressedKey) => {
-        const keyPattern = getKeyPattern();
-
-        return keyPattern.test(pressedKey);
-    }
 
     const getKeyPattern = () => {
         let keyPattern;

--- a/src/simpleMask.js
+++ b/src/simpleMask.js
@@ -106,11 +106,11 @@ const simpleMask = (containerEl, options = {}) => {
     };
 
     /* Assume value is masked if it contains at least one special character */
-    const isValueMasked = value => {
-        return value.split('').some(char => 
-            arrayOfSpecialCharactersInFormat.some(specialChar => specialChar.char === char)
+    const isValueMasked = value =>
+        arrayOfSpecialCharactersInFormat.some(specialChar => 
+            value.indexOf(specialChar.char) > -1
         );
-    }
+
 
     const getMaskMethod = (e) => e.type === 'focusin' ? maskMethods.reverse : maskMethods.forward;
 

--- a/src/simpleMask.spec.js
+++ b/src/simpleMask.spec.js
@@ -35,6 +35,12 @@ describe('Mask functionality', () => {
         inputEl.dispatchEvent(focusEvent);
         expect(inputEl.value).toBe('111111111');
     });
+
+    it('Should not mask an already-masked value', () => {
+        inputEl.dispatchEvent(new FocusEvent('focusout'));
+        inputEl.dispatchEvent(new Event('change'));
+        expect(inputEl.value).toBe('111-11-1111');
+    });
 });
 
 

--- a/src/simpleMask.spec.js
+++ b/src/simpleMask.spec.js
@@ -37,6 +37,48 @@ describe('Mask functionality', () => {
     });
 });
 
+
+describe('Input validation', () => {
+    let containerEl;
+    let inputEl;
+
+    beforeEach(() => {      
+        document.body.innerHTML = `
+            <div class="container">
+                <input value=""></input>
+            </div>`;
+        containerEl = document.querySelector('.container');
+        inputEl = containerEl.querySelector('input');
+    });
+
+    it('Should remove invalid characters after input', () => {
+        simpleMask(containerEl, {
+            inputSelector: 'input',
+            format: 'XXX-XXX-XXXX',
+            numeric: true
+        });
+
+        inputEl.value = 'abc123';
+        inputEl.dispatchEvent(new Event('input'));
+
+        expect(inputEl.value).toBe('123');
+    });
+
+    it('Should trim the length of the input value when input changes', () => {
+        simpleMask(containerEl, {
+            inputSelector: 'input',
+            format: 'XXX-XXX-XXXX',
+            numeric: true
+        });
+
+        inputEl.value = 'abc1234567abc12345abc';
+        inputEl.dispatchEvent(new Event('input'));
+
+        expect(inputEl.value).toBe('1234567123');
+    });
+
+});
+
 describe('Destroy', () => {
     let containerEl;
     let inputEl;
@@ -55,13 +97,13 @@ describe('Destroy', () => {
 
         const simpleMaskInst = simpleMask(containerEl, {
             inputSelector: 'input',
-            format: 'XXX-XX-XXXX',
+            format: 'XXX-XXX-XXXX',
             numeric: true
         });
 
         simpleMaskInst.destroy();
 
-        expect(removeEventListenerSpy).toHaveBeenCalledTimes(3);
+        expect(removeEventListenerSpy).toHaveBeenCalledTimes(4);
 
         removeEventListenerSpy.mockRestore();
     });


### PR DESCRIPTION
There are multiple ways to input a value into a textbox besides a keyboard, including:

- A browser's AutoFill feature
- Copy/paste
- Text-to-speech tools

The simpleMask plugin was only using the `keypress` event to detect input changes and the `focusout` event to determine when it should mask the textbox's value. 

This PR switches out the `keypress` event for the `input` event, which fires whenever the input changes, rather than just when the input is changed via a key press. And on a related note, the keypress event is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event).

This PR also adds a listener for the `change` event, because Chrome's AutoFill feature does not fire a `focusout` event, so the autofilled value was not getting formatted. Additionally, I added an additional condition in the `maskInput` function so that an already masked value does not get masked again. This is possible in Firefox, where an autofilled value fires both the `focusout` and `change` events.

One last note: I updated the default `numberPattern`, because it had a `/` character in it (not sure why?).